### PR TITLE
updated panel class name to fix console warning

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -40,7 +40,7 @@ class CloseCommandPortOperator(bpy.types.Operator):
         return {'FINISHED'}
 
 
-class BlenderCommandPortPanel(Panel):
+class BLENDERCOMMANDPORT1_PT_Panel(Panel):
     bl_label = 'Blender Command Port'
     bl_space_type = 'PROPERTIES'
     bl_region_type = 'WINDOW'
@@ -73,12 +73,12 @@ def register():
     bpy.utils.register_class(OpenCommandPortOperator)
     bpy.utils.register_class(CloseCommandPortOperator)
     register_command_port()
-    bpy.utils.register_class(BlenderCommandPortPanel)
+    bpy.utils.register_class(BLENDERCOMMANDPORT1_PT_Panel)
 
 
 def unregister():
     bpy.utils.unregister_class(OpenCommandPortOperator)
     bpy.utils.unregister_class(CloseCommandPortOperator)
     unregister_command_port()
-    bpy.utils.unregister_class(BlenderCommandPortPanel)
+    bpy.utils.unregister_class(BLENDERCOMMANDPORT1_PT_Panel)
 


### PR DESCRIPTION
This fixes the console warning which occurs in Blender 2.80 once the addon is installed. 
It is merely a naming convention change at lines 43, 76 & 83. 
I would imagine you would prefer to use a better name than the one I've used so feel free to close this pull request. 

New naming convention can be found at:

[https://wiki.blender.org/wiki/Reference/Release_Notes/2.80/Python_API/Addons](https://wiki.blender.org/wiki/Reference/Release_Notes/2.80/Python_API/Addons)