### PR TITLE
Update __init__.py

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -43,15 +43,16 @@ class CloseCommandPortOperator(bpy.types.Operator):
 class BLENDERCOMMANDPORT1_PT_Panel(Panel):
     bl_label = 'Blender Command Port'
 
-    # 2.8 uses PREFERENCES, 2.7 uses USER_PREFERENCES, detect:
+    # 2.8 uses PREFERENCES and system, 2.7 uses USER_PREFERENCES and data, detect:
     try:
         bpy.types.SpacePreferences
         bl_space_type = 'PREFERENCES'
+        bl_context = 'system'
     except AttributeError:
         bl_space_type = 'USER_PREFERENCES'
+        bl_context = 'data'
 
     bl_region_type = 'WINDOW'
-    bl_context = 'data'
 
     def draw(self, context):
         layout = self.layout

--- a/__init__.py
+++ b/__init__.py
@@ -1,8 +1,10 @@
 bl_info = {
     "name": "Blender Command Port",
     "description": "Command Port implementation for blender. "
-                   "www.github.com/p4vv37/blender_command_port",
+                   "www.github.com/p4vv37/blender_command_port"
+                   "www.github.com/jeffhanna/blender_command_port",
     "author": "Pawel Kowalski",
+    "author": "Jeff Hanna"
     "version": (1, 0, 1),
     "blender": (2, 80, 0),
     "location": "User preferences > Blender Command Port",
@@ -43,15 +45,12 @@ class CloseCommandPortOperator(bpy.types.Operator):
 class BLENDERCOMMANDPORT1_PT_Panel(Panel):
     bl_label = 'Blender Command Port'
 
-    # 2.8 uses PREFERENCES and system, 2.7 uses USER_PREFERENCES and data, detect:
-    try:
-        bpy.types.SpacePreferences
-        bl_space_type = 'PREFERENCES'
-        bl_context = 'system'
-    except AttributeError:
-        bl_space_type = 'USER_PREFERENCES'
-        bl_context = 'data'
-
+    # 2.8 uses PREFERENCES and system. There is no need to attempt to context
+    # switch between Blender 2.7 and 2.8 here as the 'blender' version metadata 
+    # at the top of this file limits it to Blender 2.80 or later.
+    
+    bl_space_type = 'PREFERENCES'
+    bl_context = 'system'
     bl_region_type = 'WINDOW'
 
     def draw(self, context):


### PR DESCRIPTION
Two changes needed to be made to ensure Blender Command Port works correctly in Blender 2.8+. Along with the bl_space_type change to PREFERENCES the bl_context also needs to be changed to 'system' as there is no 'data' context in the Blender 2.8+ preferences dialog. My changes to this module's __init__.py file include the correct bl_context assignment where the bl_space_type assignment is being made as determined by which version of Blender (2.7x or 2.8+) is being used.