### PR TITLE
Update API usage, fixes issue #18

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -4,8 +4,8 @@ bl_info = {
                    "www.github.com/p4vv37/blender_command_port"
                    "www.github.com/jeffhanna/blender_command_port",
     "author": "Pawel Kowalski, Jeff Hannna",
-    "version": (1, 2, 1),
-    "blender": (2, 80, 0),
+    "version": (1, 2, 2),
+    "blender": (2, 93, 0),
     "location": "User preferences > Blender Command Port",
     "support": "COMMUNITY",
     "wiki_url": "www.github.com/p4vv37/blender_command_port",

--- a/command_port.py
+++ b/command_port.py
@@ -82,7 +82,7 @@ class CommandPort(threading.Thread):
         # So I'm detecting if a main thread of blender did finish working.
         # If it did, then I'm breaking the loop and closing the port.
         threads = threading.enumerate()
-        while any([t.name == "MainThread" and t.isAlive() for t in threads]):
+        while any([t.name == "MainThread" and t.is_alive() for t in threads]):
             if not self.do_run:
                 # ---- Break also if user requested closing the port.
                 print("do_run is False")


### PR DESCRIPTION
#18 Gives the fix for use with newer versions of Blender, We have implemented this change and tested as 
far back as 2.93 LTS, the oldest supported LTS release. 

Increments the version to 1.2.2, and blender version to 2.93.

Newest version tested: Blender 3.5.1

Edit: also covers the second issue mentioned in #17 